### PR TITLE
Fix the set image block so that the image is a value and not a field

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -133,8 +133,9 @@ namespace sprites {
     /**
      * Sets an Image in the data of a sprite
      */
-    //% blockId=spriteDataSetImageValue block="set $sprite=variables_get data $name to image $value"
+    //% blockId=spriteDataSetImageValue block="set $sprite data $name to image $value"
     //% group="Data"
+    //% sprite.shadow=variables_get
     //% value.shadow=screen_image_picker
     //% weight=9
     //% blockGap=8

--- a/main.ts
+++ b/main.ts
@@ -118,13 +118,27 @@ namespace sprites {
 
 
     /**
-     * Sets a sprite in the data of a sprite
+     * Sets an Image in the data of a sprite.
+     * Deprecated. Use setDataImageValue instead
      */
     //% blockId=spriteDataSetImage block="set $sprite=variables_get data $name to image $value"
     //% group="Data"
+    //% deprecated=1
     //% weight=9
     //% blockGap=8
     export function setDataImage(sprite: Sprite, name: string, value: Image) {
+        setDataImageValue(sprite, name, value);
+    }
+
+    /**
+     * Sets an Image in the data of a sprite
+     */
+    //% blockId=spriteDataSetImageValue block="set $sprite=variables_get data $name to image $value"
+    //% group="Data"
+    //% value.shadow=screen_image_picker
+    //% weight=9
+    //% blockGap=8
+    export function setDataImageValue(sprite: Sprite, name: string, value: Image) {
         if (!sprite || !name) return;
         const d = sprite.data;
         d[name] = value;


### PR DESCRIPTION
Fixes https://github.com/microsoft/pxt-arcade/issues/2387

Deprecated the old block and added this one instead:

<img width="562" alt="Screen Shot 2020-09-02 at 4 55 46 PM" src="https://user-images.githubusercontent.com/13754588/92048754-661a2980-ed3d-11ea-9e82-a96089660e46.png">
